### PR TITLE
Split out ubxlib specific things to separate files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,23 @@
 cmake_minimum_required(VERSION 3.4)
-set(APP_NAME at_client)
-project(${APP_NAME})
+project(at_client)
 string(TOLOWER  ${CMAKE_SYSTEM_NAME} OS_NAME)
 file(REAL_PATH "~" HOME EXPAND_TILDE)
 
-# This application
-add_executable(${APP_NAME} u_cx_at_client.c u_cx_at_util.c main.c)
-
 if (DEFINED ENV{UBXLIB_DIR})
+  set(APP_NAME_UBXLIB at_client)
+  # This application
+  add_executable(${APP_NAME_UBXLIB} u_cx_at_client.c u_cx_at_util.c u_ubxlib_main.c)
+
   # Get and build the ubxlib library
   set(UBXLIB_BASE $ENV{UBXLIB_DIR})
   include(${UBXLIB_BASE}/port/platform/${OS_NAME}/${OS_NAME}.cmake)
-  target_link_libraries(${APP_NAME} ubxlib ${UBXLIB_REQUIRED_LINK_LIBS})
-  target_include_directories(${APP_NAME} PUBLIC ${UBXLIB_INC} ${UBXLIB_PUBLIC_INC_PORT})
+  target_link_libraries(${APP_NAME_UBXLIB} ubxlib ${UBXLIB_REQUIRED_LINK_LIBS})
+  target_include_directories(${APP_NAME_UBXLIB} PUBLIC ${UBXLIB_INC} ${UBXLIB_PUBLIC_INC_PORT})
 else()
-  message(FATAL_ERROR "Ubxlib location not defined")
+  message(WARNING "Ubxlib location not defined (UBXLIB_BASE) - not building ubxlib app")
 endif()
+
+
+set(APP_NAME_TEST at_client_test)
+# This application
+add_executable(${APP_NAME_TEST} u_cx_at_client.c u_cx_at_util.c u_main_test.c)

--- a/u_cx_at_client.h
+++ b/u_cx_at_client.h
@@ -15,7 +15,7 @@
  * COMPILE-TIME MACROS
  * -------------------------------------------------------------- */
 
-typedef struct {
+typedef struct uCxAtClient {
     void *streamHandle;
     char *pRxBuffer;
     size_t rxBufferLen;

--- a/u_cx_at_config.h
+++ b/u_cx_at_config.h
@@ -1,0 +1,32 @@
+/** @file
+ * @brief Configuration file for the uCX AT client
+ */
+#ifndef U_CX_AT_CONFIG_H
+#define U_CX_AT_CONFIG_H
+
+/* To override the default settings you can define U_CX_AT_CONFIG_FILE
+ * to include a custom configuration header file
+ */
+#ifdef U_CX_AT_CONFIG_FILE
+# include U_CX_AT_CONFIG_FILE
+#endif
+
+struct uCxAtClient;
+
+/* U_CX_AT_PORT_WRITE can be used to redefine the function that will be called
+ * when writing to the AT interface (typically UART)
+ */
+#ifndef U_CX_AT_PORT_WRITE
+extern size_t uCxAtWrite(struct uCxAtClient *pClient, const void *pData, size_t length);
+# define U_CX_AT_PORT_WRITE(AT_CLIENT, DATA, DATA_LEN) uCxAtWrite(AT_CLIENT, DATA, DATA_LEN)
+#endif
+
+/* U_CX_AT_PORT_READ can be used to redefine the function that will be called
+ * when reading from the AT interface (typically UART)
+ */
+#ifndef U_CX_AT_PORT_READ
+extern size_t uCxAtRead(struct uCxAtClient *pClient, void *pData, size_t length);
+# define U_CX_AT_PORT_READ(AT_CLIENT, DATA, DATA_LEN) uCxAtRead(AT_CLIENT, DATA, DATA_LEN)
+#endif
+
+#endif // U_CX_AT_CONFIG_H

--- a/u_cx_at_util.c
+++ b/u_cx_at_util.c
@@ -146,7 +146,7 @@ int uCxAtUtilParseParamsVaList(char *pParams, const char *pParamFmt, va_list arg
                     return -ret;
                 }
                 *pLen = len / 2;
-                pBytes = pParam;
+                pBytes = (uint8_t *)pParam;
                 *ppData = pBytes;
                 for (int i = 0; i < *pLen; i++) {
                     if (uCxAtUtilHexToByte(&pParam[i * 2], pBytes) < 0) {

--- a/u_main_test.c
+++ b/u_main_test.c
@@ -1,9 +1,20 @@
 #include <string.h>
 #include <stdio.h>
-#include "ubxlib.h"
 
 #include "u_cx_at_client.h"
 #include "u_cx_at_util.h"
+
+size_t uCxAtRead(struct uCxAtClient *pClient, void *pData, size_t length)
+{
+    (void)pClient;
+    return fread(pData, 1, length, stdin);
+}
+
+void uCxAtWrite(struct uCxAtClient *pClient, const void *pData, size_t length)
+{
+    (void)pClient;
+    fwrite(pData, 1, length, stdout);
+}
 
 void myUrc(char *pUrcLine)
 {
@@ -27,25 +38,7 @@ int main(void)
     printf("len: %d, pData: %02x%02x%02x%02x%02x%02x\n", len, pData[0], pData[1], pData[2], pData[3],
            pData[4], pData[5]);
 
-    // Initiate ubxlib
-    uPortInit();
-    // Get the uart
-    uPortUartInit();
-    int32_t handleOrErrorCode = uPortUartOpen(
-                                    0,
-                                    115200,
-                                    NULL,
-                                    1024,
-                                    -1,
-                                    -1,
-                                    -1,
-                                    -1);
-    if (handleOrErrorCode < 0) {
-        printf("* Failed to open uart\n");
-        return 1;
-    }
-
-    uCxAtClientInit(U_INT32_TO_PTR(handleOrErrorCode), rxBuf, sizeof(rxBuf), &client);
+    uCxAtClientInit(NULL, rxBuf, sizeof(rxBuf), &client);
     uCxAtClientExecSimpleCmd(&client, "ATE0");
     client.urcCallback = myUrc;
     for (int i = 0; i < 3; i++) {

--- a/u_ubxlib_main.c
+++ b/u_ubxlib_main.c
@@ -1,0 +1,82 @@
+/** @file
+ * @brief Short description of the purpose of the file
+ */
+#include <stdio.h>
+
+#include "ubxlib.h"
+#include "u_cx_at_client.h"
+
+/* ----------------------------------------------------------------
+ * COMPILE-TIME MACROS
+ * -------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------
+ * TYPES
+ * -------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------
+ * STATIC PROTOTYPES
+ * -------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------
+ * STATIC VARIABLES
+ * -------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------
+ * STATIC FUNCTIONS
+ * -------------------------------------------------------------- */
+
+static void urcHandler(char *pUrcLine)
+{
+    printf("Got URC: %s\n", pUrcLine);
+}
+
+/* ----------------------------------------------------------------
+ * PUBLIC FUNCTIONS
+ * -------------------------------------------------------------- */
+
+size_t uCxAtRead(struct uCxAtClient *pClient, void *pData, size_t length)
+{
+    return uPortUartRead(U_PTR_TO_INT32(pClient->streamHandle), pData, length);
+}
+
+void uCxAtWrite(struct uCxAtClient *pClient, const void *pData, size_t length)
+{
+    uPortUartWrite(U_PTR_TO_INT32(pClient->streamHandle), pData, length);
+}
+
+int main(void)
+{
+    char rxBuf[1024];
+    uCxAtClient_t client;
+
+    // Initiate ubxlib
+    uPortInit();
+    // Get the uart
+    uPortUartInit();
+    int32_t handleOrErrorCode = uPortUartOpen(
+                                    0,
+                                    115200,
+                                    NULL,
+                                    1024,
+                                    -1,
+                                    -1,
+                                    -1,
+                                    -1);
+    if (handleOrErrorCode < 0) {
+        printf("* Failed to open uart\n");
+        return 1;
+    }
+
+    uCxAtClientInit(U_INT32_TO_PTR(handleOrErrorCode), rxBuf, sizeof(rxBuf), &client);
+    uCxAtClientExecSimpleCmd(&client, "ATE0");
+    client.urcCallback = urcHandler;
+    for (int i = 0; i < 3; i++) {
+        uCxAtClientCmdBeginF(&client, "ATI", "d", 9, U_CX_AT_UTIL_PARAM_LAST);
+        char *pRsp = uCxAtClientCmdGetRspParamLine(&client, "");
+        if (pRsp) {
+            printf("%d Got response: %s\n", i, pRsp);
+        }
+        uCxAtClientCmdEnd(&client);
+    }
+}


### PR DESCRIPTION
This commit will add a very basic porting layer for reading and writing to the AT interface.

The ubxlib releated things are now split out to separate files so that there are no direct dependency from u_cx_at_client to ubxlib.

CMake project is updated to build two binaries:
"at_client" - The ubxlib ported AT client using u_port_uart "at_client_test" - The old testing client using stdin/stdout

If UBXLIB_BASE env. variable is not set, then only "at_client_test" is built.