### PR TITLE
Enable some more compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,5 +32,6 @@ add_executable(${APP_NAME_TEST}
 )
 find_package(Threads REQUIRED)
 target_link_libraries(${APP_NAME_TEST} PRIVATE Threads::Threads)
+target_compile_options(${APP_NAME_TEST} PRIVATE -Wall -Werror)
 
 target_include_directories(${APP_NAME_TEST} PUBLIC ${UBXLIB_INC} ${UBXLIB_PUBLIC_INC_PORT} inc ucx_api)

--- a/project.yml
+++ b/project.yml
@@ -168,6 +168,8 @@
             - -fsanitize=address
             - -fno-omit-frame-pointer
             - -DU_CX_LOG_AT=0
+            - -O1  # Set O1 so that GCC correctly detects uninitialized variables: https://stackoverflow.com/questions/17705880/gcc-failing-to-warn-of-uninitialized-variable
+            - -Wno-clobbered # Needed when enabling -O1 for disabling warning in the CMock runners
     :link:
         :*:
             - -fsanitize=address
@@ -179,6 +181,8 @@
             - -Wextra
             - -fsanitize=address
             - -fno-omit-frame-pointer
+            - -O1  # Set O1 so that GCC correctly detects uninitialized variables: https://stackoverflow.com/questions/17705880/gcc-failing-to-warn-of-uninitialized-variable
+            - -Wno-clobbered # Needed when enabling -O1 for disabling warning in the CMock runners
     :link:
         :*:
             - -fsanitize=address

--- a/test/test_u_cx_at_utils.c
+++ b/test/test_u_cx_at_utils.c
@@ -197,7 +197,7 @@ void test_uCxAtUtilHexToBinary_withValidValues_expectSuccess(void)
         memset(buffer, 0xFF, sizeof(buffer));
         uint32_t ret = uCxAtUtilHexToBinary(seq1[i], buffer, sizeof(buffer));
         TEST_ASSERT_EQUAL_UINT(strlen(seq1[i]) / 2, ret);
-        for (uint32_t j; j < ret; j++) {
+        for (uint32_t j = 0; j < ret; j++) {
             TEST_ASSERT_EQUAL_INT(j, buffer[j]);
         }
     }


### PR DESCRIPTION
Some compiler warnings are not detected unless you enable some compiler optimization:  
https://stackoverflow.com/questions/17705880/gcc-failing-to-warn-of-uninitialized-variable