### PR TITLE
Add a debug and warning log channel

### DIFF
--- a/inc/u_cx_at_config.h
+++ b/inc/u_cx_at_config.h
@@ -45,9 +45,19 @@ extern int32_t uPortGetTickTimeMs(void);
 # define U_CX_PORT_GET_TIME_MS()   uPortGetTickTimeMs()
 #endif
 
-/* Configuration for enabling logging off AT protocol.*/
+/* Configuration for enabling logging of AT protocol.*/
 #ifndef U_CX_LOG_AT
 # define U_CX_LOG_AT 1
+#endif
+
+/* Configuration for enabling logging of warning messages.*/
+#ifndef U_CX_LOG_WARNING
+# define U_CX_LOG_WARNING 1
+#endif
+
+/* Configuration for enabling logging of debug messages.*/
+#ifndef U_CX_LOG_DEBUG
+# define U_CX_LOG_DEBUG 0
 #endif
 
 /* Configuration for enabling ANSI color for logs.*/

--- a/inc/u_cx_log.h
+++ b/inc/u_cx_log.h
@@ -15,8 +15,10 @@
  * -------------------------------------------------------------- */
 
 /* Log channels (used as input for U_CX_LOG_BEGIN() and U_CX_LOG_LINE()) */
-#define U_CX_LOG_CHANNEL_TX     U_CX_LOG_AT, ANSI_CYN "[AT TX]"
-#define U_CX_LOG_CHANNEL_RX     U_CX_LOG_AT, ANSI_MAG "[AT RX]"
+#define U_CX_LOG_CH_TX     U_CX_LOG_AT,        ANSI_CYN "[AT TX]"
+#define U_CX_LOG_CH_RX     U_CX_LOG_AT,        ANSI_MAG "[AT RX]"
+#define U_CX_LOG_CH_DBG    U_CX_LOG_DEBUG,     ANSI_RST "[DBG  ]"
+#define U_CX_LOG_CH_WARN   U_CX_LOG_WARNING,   ANSI_YEL "[WARN ]"
 
 /* Simple line logging printf style (\n will be added automatically) */
 #define U_CX_LOG_LINE(logCh, format, ...)  _U_CX_LOG_BEGIN_FMT(logCh, format ANSI_RST "\n", ##__VA_ARGS__)

--- a/ucx_api/u_cx.c
+++ b/ucx_api/u_cx.c
@@ -7,6 +7,8 @@
 #include <string.h>  // memcpy(), strcmp(), strcspn(), strspm()
 #include <stdio.h>
 
+#include "u_cx_log.h"
+
 #include "u_cx.h"
 
 /* ----------------------------------------------------------------
@@ -46,7 +48,8 @@ static void urcCallback(struct uCxAtClient *pClient, void *pTag, char *pLine, si
         pParams++;
         paramLen--;
     }
-    printf("name is '%s', params are: '%s'\n", pLine, pParams);
+
+    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "Received URC '%s', params: '%s'", pLine, pParams);
     extern int32_t uCxUrcParse(uCxHandle_t * puCxHandle, const char * pUrcName, char * pParams, size_t paramsLength);
     uCxUrcParse(puCxHandle, pLine, pParams, paramLen);
 }


### PR DESCRIPTION
These two channels can be enabled/disabled with these defines: 
* U_CX_LOG_WARNING
* U_CX_LOG_DEBUG

Example output:
![image](https://github.com/antevir/at-client/assets/15906458/a0523de8-bece-4b5d-a05c-c2f5a4f4aebf)
