### PR TITLE
Add compile option to disable URC queue

### DIFF
--- a/inc/u_cx_at_client.h
+++ b/inc/u_cx_at_client.h
@@ -63,7 +63,9 @@ typedef struct uCxAtClient {
     int32_t lastIoError;
     uUrcCallback_t urcCallback;
     void *pUrcCallbackTag;
+#if U_CX_USE_URC_QUEUE == 1
     uCxAtUrcQueue_t urcQueue;
+#endif
     bool isBinaryRx;
     uCxAtBinaryRx_t binaryRx;
     uCxAtBinaryResponseBuf_t rspBinaryBuf;
@@ -73,8 +75,10 @@ typedef struct uCxAtClient {
 typedef struct uCxAtClientConfig {
     void *pRxBuffer;        /**< Pointer to a buffer that the client will use as RX buffer */
     size_t rxBufferLen;     /**< Size of the RX buffer. */
+#if U_CX_USE_URC_QUEUE == 1
     void *pUrcBuffer;       /**< Pointer to a separate URC buffer */
     size_t urcBufferLen;    /**< Size of the URC buffer. */
+#endif
     void *pStreamHandle;    /**< User pointer associated with the AT interface.
                                  This pointer will be passed to write and read functions below
                                  and can be used to talk to a certain COM port etc.*/

--- a/inc/u_cx_at_config.h
+++ b/inc/u_cx_at_config.h
@@ -45,6 +45,20 @@ extern int32_t uPortGetTickTimeMs(void);
 # define U_CX_PORT_GET_TIME_MS()   uPortGetTickTimeMs()
 #endif
 
+/* Configuration for enabling URC queue
+ *
+ * With "U_CX_USE_URC_QUEUE 1" you can execute new AT commands directly
+ * in the URC callback. However, this comes with some penalty as you need
+ * to provide the AT client with an extra URC queue buffer and whenever an
+ * URC is received it will be copied from the rxBuffer to the URC buffer.
+ *
+ * NOTE: With "U_CX_USE_URC_QUEUE 0" you must never execute any AT command
+ *       directly from the URC callback.
+ */
+#ifndef U_CX_USE_URC_QUEUE
+# define U_CX_USE_URC_QUEUE 1
+#endif
+
 /* Configuration for enabling logging of AT protocol.*/
 #ifndef U_CX_LOG_AT
 # define U_CX_LOG_AT 1
@@ -92,6 +106,5 @@ extern int32_t uPortGetTickTimeMs(void);
 // Return value when IO (read) returns negative value
 # define U_CX_ERROR_IO              -0x10001
 #endif
-
 
 #endif // U_CX_AT_CONFIG_H

--- a/project.yml
+++ b/project.yml
@@ -49,6 +49,8 @@
   :test_preprocess:
     - *common_defines
     - TEST
+  :test_u_cx_at_client_no_urc_queue:
+    - U_CX_USE_URC_QUEUE=0
 
 :cmock:
   :mock_prefix: mock_

--- a/src/u_cx_at_client.c
+++ b/src/u_cx_at_client.c
@@ -129,6 +129,7 @@ static int32_t parseLine(uCxAtClient_t *pClient, char *pLine, size_t lineLength)
                 ret = AT_PARSER_GOT_URC;
             } else {
                 // Urc queue full
+                U_CX_LOG_LINE(U_CX_LOG_CH_WARN, "URC queue full - dropping URC");
             }
 #else
             const struct uCxAtClientConfig *pConfig = pClient->pConfig;
@@ -140,6 +141,7 @@ static int32_t parseLine(uCxAtClient_t *pClient, char *pLine, size_t lineLength)
         } else {
             // Received unexpected data
             // TODO: Handle
+            U_CX_LOG_LINE(U_CX_LOG_CH_WARN, "Unexpected data");
         }
     }
 
@@ -208,6 +210,7 @@ static void setupBinaryTransfer(uCxAtClient_t *pClient, int32_t parserRet, uint1
                 setupBinaryRxBuffer(pClient, U_CX_BIN_STATE_BINARY_URC, pPtr, len, binLength);
             } else {
                 // The binary data can't be fitted into the queue so we need to drop it
+                U_CX_LOG_LINE(U_CX_LOG_CH_WARN, "Not enough space for URC binary data");
                 uCxAtUrcQueueEnqueueAbort(&pClient->urcQueue);
                 setupBinaryRxBuffer(pClient, U_CX_BIN_STATE_BINARY_FLUSH, NULL, 0, binLength);
             }
@@ -220,6 +223,7 @@ static void setupBinaryTransfer(uCxAtClient_t *pClient, int32_t parserRet, uint1
                                     &pPtr[bufPos], len, binLength);
             } else {
                 // The binary data can't be fitted into the queue so we need to drop it
+                U_CX_LOG_LINE(U_CX_LOG_CH_WARN, "Not enough space for URC binary data");
                 setupBinaryRxBuffer(pClient, U_CX_BIN_STATE_BINARY_FLUSH, NULL, 0, binLength);
             }
 #endif
@@ -227,6 +231,7 @@ static void setupBinaryTransfer(uCxAtClient_t *pClient, int32_t parserRet, uint1
         }
         default:
             // Unexpected data - just flush it
+            U_CX_LOG_LINE(U_CX_LOG_CH_WARN, "Unexpected binary data");
             setupBinaryRxBuffer(pClient, U_CX_BIN_STATE_BINARY_FLUSH, NULL, 0, binLength);
             break;
     }

--- a/src/u_cx_at_client.c
+++ b/src/u_cx_at_client.c
@@ -376,7 +376,10 @@ static void processUrcs(uCxAtClient_t *pClient)
         }
         if (pClient->urcCallback) {
             char *pUrcLine = (char *)&pEntry->data[0];
-            uint8_t *pPayload = &pEntry->data[pEntry->strLineLen + 1];
+            uint8_t *pPayload = NULL;
+            if (pEntry->payloadSize > 0) {
+                pPayload = &pEntry->data[pEntry->strLineLen + 1];
+            }
             pClient->urcCallback(pClient, pClient->pUrcCallbackTag, pUrcLine,
                                  pEntry->strLineLen, pPayload, pEntry->payloadSize);
         }

--- a/src/u_cx_at_urc_queue.c
+++ b/src/u_cx_at_urc_queue.c
@@ -10,6 +10,8 @@
 #include "u_cx_log.h"
 #include "u_cx_at_urc_queue.h"
 
+#if U_CX_USE_URC_QUEUE == 1
+
 /* ----------------------------------------------------------------
  * COMPILE-TIME MACROS
  * -------------------------------------------------------------- */
@@ -161,3 +163,5 @@ void uCxAtUrcQueueDequeueEnd(uCxAtUrcQueue_t *pUrcQueue, uUrcEntry_t *pEntry)
 
     U_CX_MUTEX_UNLOCK(pUrcQueue->dequeueMutex);
 }
+
+#endif // U_CX_USE_URC_QUEUE == 1

--- a/test/test_u_cx_at_client_no_urc_queue.c
+++ b/test/test_u_cx_at_client_no_urc_queue.c
@@ -1,0 +1,169 @@
+#include <string.h>
+#include <stdbool.h>
+
+#include "unity.h"
+#include "mock_u_cx_log.h"
+#include "mock_u_cx_at_config.h"
+#include "u_cx_at_util.h"
+#include "u_cx_at_params.h"
+#include "u_cx_at_urc_queue.h"
+#include "u_cx_at_client.h"
+
+/* ----------------------------------------------------------------
+ * COMPILE-TIME MACROS
+ * -------------------------------------------------------------- */
+
+#define CONTEXT_VALUE  ((void *)0x11223344)
+#define STREAM_HANDLER ((void *)0x44332211)
+
+#define BIN_HDR(DATA_LENGTH) \
+    0x01,(DATA_LENGTH) >> 8,(DATA_LENGTH) & 0xFF
+
+#define TEST_URC "+MYURC:123,\"abc\""
+
+/* ----------------------------------------------------------------
+ * TYPES
+ * -------------------------------------------------------------- */
+
+static int32_t write(uCxAtClient_t *pClient, void *pStreamHandle,
+                     const void *pData, size_t length);
+
+static int32_t read(uCxAtClient_t *pClient, void *pStreamHandle,
+                    void *pData, size_t length, int32_t timeoutMs);
+
+
+/* ----------------------------------------------------------------
+ * STATIC VARIABLES
+ * -------------------------------------------------------------- */
+
+static uint8_t gRxBuffer[1024];
+
+static uint8_t gTxBuffer[1024];
+static size_t gTxBufferPos;
+
+static uint8_t *gPRxDataPtr;
+static int32_t gRxDataLen;
+static int32_t gRxIoErrorCode;
+
+static uCxAtClientConfig_t gClientConfig = {
+    .pContext = CONTEXT_VALUE,
+    .pRxBuffer = gRxBuffer,
+    .rxBufferLen = sizeof(gRxBuffer),
+    .pStreamHandle = STREAM_HANDLER,
+    .read = read,
+    .write = write,
+};
+
+static uCxAtClient_t gClient;
+
+/* ----------------------------------------------------------------
+ * STATIC FUNCTIONS
+ * -------------------------------------------------------------- */
+
+static int32_t write(uCxAtClient_t *pClient, void *pStreamHandle,
+                     const void *pData, size_t length)
+{
+    TEST_ASSERT_EQUAL(&gClient, pClient);
+    TEST_ASSERT_EQUAL(STREAM_HANDLER, pStreamHandle);
+    assert(length < sizeof(gTxBuffer) - gTxBufferPos);
+    memcpy(&gTxBuffer[gTxBufferPos], pData, length);
+    gTxBufferPos += length;
+    return length;
+}
+
+static int32_t read(uCxAtClient_t *pClient, void *pStreamHandle,
+                    void *pData, size_t length, int32_t timeoutMs)
+{
+    static int zeroCounter = 0;
+    (void)timeoutMs;
+    TEST_ASSERT_EQUAL(&gClient, pClient);
+    TEST_ASSERT_EQUAL(STREAM_HANDLER, pStreamHandle);
+
+    if (gRxIoErrorCode != 0) {
+        if (++zeroCounter > 10) {
+            TEST_FAIL_MESSAGE("Stuck in read loop");
+        }
+        return gRxIoErrorCode;
+    }
+
+    int32_t cpyLen = U_MIN((int32_t)length, gRxDataLen);
+    if (cpyLen > 0) {
+        memcpy(pData, gPRxDataPtr, cpyLen);
+        gPRxDataPtr += cpyLen;
+        gRxDataLen -= cpyLen;
+        zeroCounter = 0;
+    } else {
+        if (++zeroCounter > 10) {
+            TEST_FAIL_MESSAGE("Stuck in read loop");
+        }
+    }
+    return cpyLen;
+}
+
+/* ----------------------------------------------------------------
+ * TEST FUNCTIONS
+ * -------------------------------------------------------------- */
+
+void setUp(void)
+{
+    uCxLogPrintTime_Ignore();
+    uCxLogIsEnabled_IgnoreAndReturn(false);
+    uCxAtClientInit(&gClientConfig, &gClient);
+    memset(&gTxBuffer[0], 0xc0, sizeof(gTxBuffer));
+    gTxBufferPos = 0;
+    gPRxDataPtr = NULL;
+    gRxDataLen = -1;
+    gRxIoErrorCode = 0;
+
+    uPortGetTickTimeMs_IgnoreAndReturn(0);
+}
+
+void tearDown(void)
+{
+}
+
+void test_uCxAtClientHandleRx_withStringUrc_expectUrcCallback(void)
+{
+    char rxData[] = { "\r\n" TEST_URC "\r\n" };
+    gPRxDataPtr = (uint8_t *)&rxData[0];
+    gRxDataLen = strlen(rxData);
+
+    void urcCallback(struct uCxAtClient *pClient, void *pTag, char *pLine,
+                     size_t lineLength, uint8_t *pBinaryData, size_t binaryDataLen)
+    {
+        TEST_ASSERT_EQUAL(&gClient, pClient);
+        TEST_ASSERT_NULL(pTag);
+        TEST_ASSERT_EQUAL_STRING(TEST_URC, pLine);
+        TEST_ASSERT_EQUAL(strlen(pLine), lineLength);
+        TEST_ASSERT_NULL(pBinaryData);
+        TEST_ASSERT_EQUAL(0, binaryDataLen);
+    }
+
+    uCxAtClientSetUrcCallback(&gClient, urcCallback, NULL);
+    uCxAtClientHandleRx(&gClient);
+}
+
+void test_uCxAtClientHandleRx_withBinUrc_expectUrcCallback(void)
+{
+    char strData[] = { "\r\n" TEST_URC };
+    uint8_t binData[] = {BIN_HDR(6),0x00,0x11,0x22,0x33,0x44,0x55};
+    uint8_t rxData[strlen(strData) + sizeof(binData)];
+    memcpy(&rxData[0], &strData[0], strlen(strData));
+    memcpy(&rxData[strlen(strData)], &binData[0], sizeof(binData));
+    gPRxDataPtr = &rxData[0];
+    gRxDataLen += strlen(strData) + sizeof(binData);
+
+    void urcCallback(struct uCxAtClient *pClient, void *pTag, char *pLine,
+                     size_t lineLength, uint8_t *pBinaryData, size_t binaryDataLen)
+    {
+        TEST_ASSERT_EQUAL(&gClient, pClient);
+        TEST_ASSERT_NULL(pTag);
+        TEST_ASSERT_EQUAL_STRING(TEST_URC, pLine);
+        TEST_ASSERT_EQUAL(strlen(pLine), lineLength);
+        TEST_ASSERT_NULL(pBinaryData);
+        TEST_ASSERT_EQUAL(0, binaryDataLen);
+    }
+
+    uCxAtClientSetUrcCallback(&gClient, urcCallback, NULL);
+    uCxAtClientHandleRx(&gClient);
+}

--- a/test/u_main_test.c
+++ b/test/u_main_test.c
@@ -86,11 +86,7 @@ static int32_t uCxAtWrite(uCxAtClient_t *pClient, void *pStreamHandle, const voi
 static void networkUpUrc(struct uCxHandle *puCxHandle)
 {
     printf("networkUpUrc\n");
-    uEchoOn_t echo;
-    uCxSystemGetEcho(puCxHandle, &echo);
-
     signalEvent(URC_FLAG_NETWORK_UP);
-    uCxSystemGetEcho(puCxHandle, &echo);
 }
 
 static void sockConnected(struct uCxHandle *puCxHandle, int32_t socket_handle)
@@ -195,12 +191,16 @@ int main(int argc, char **argv)
     uCxAtClient_t client;
 
     static char rxBuf[1024];
+#if U_CX_USE_URC_QUEUE == 1
     static char urcBuf[1024];
+#endif
     static uCxAtClientConfig_t config = {
         .pRxBuffer = &rxBuf[0],
         .rxBufferLen = sizeof(rxBuf),
+#if U_CX_USE_URC_QUEUE == 1
         .pUrcBuffer = &urcBuf[0],
         .urcBufferLen = sizeof(urcBuf),
+#endif
         .pStreamHandle = NULL,
         .write = uCxAtWrite,
         .read = uCxAtRead


### PR DESCRIPTION
The URC queue need a separate buffer and requires copying data from rxBuffer
to URC buffer. For some use cases this penalty may be undesired and in this
case the URC queue can now be disabled by defining U_CX_USE_URC_QUEUE 0