### PR TITLE
Fix for correct response handling when echo is on

### DIFF
--- a/src/u_cx_at_client.c
+++ b/src/u_cx_at_client.c
@@ -115,7 +115,7 @@ static int32_t parseLine(uCxAtClient_t *pClient, char *pLine, size_t lineLength)
                     ret = AT_PARSER_GOT_STATUS;
                 }
             }
-        } else if ((pLine[0] != '+') && (pLine[0] != '*')) {
+        } else if ((pLine[0] != '+') && (pLine[0] != '*') && (strncmp(pLine, "AT+", 3) != 0)) {
             pClient->pRspParams = &pLine[0];
             ret = AT_PARSER_GOT_RSP;
         }

--- a/test/test_u_cx_at_client.c
+++ b/test/test_u_cx_at_client.c
@@ -242,6 +242,19 @@ void test_uCxAtClientCmdGetRspParamLine_withTimeout_expectNull(void)
     TEST_ASSERT_EQUAL(NULL, uCxAtClientCmdGetRspParamLine(&gClient, "DUMMY", NULL, NULL));
 }
 
+void test_uCxAtClientCmdGetRspParamLine_withCmdEchoAndRsp_expectRsp(void)
+{
+    // Start by putting the client in command state
+    uCxAtClientCmdBeginF(&gClient, "", "", U_CX_AT_UTIL_PARAM_LAST);
+
+    char rxData[] = { "AT+FOO\r\n+MYRSP:123\r\n" };
+    gPRxDataPtr = (uint8_t *)&rxData[0];
+    gRxDataLen = sizeof(rxData);
+    char *pRsp = uCxAtClientCmdGetRspParamLine(&gClient, "+MYRSP:", NULL, NULL);
+    TEST_ASSERT_NOT_NULL(pRsp);
+    TEST_ASSERT_EQUAL_STRING("123", pRsp);
+}
+
 void test_uCxAtClientCmdGetRspParamLine_withReadError_expectNull(void)
 {
     // Start by putting the client in command state


### PR DESCRIPTION
Just ignore all responses starting with "AT+"